### PR TITLE
Post-Capella payloads aren't actually valid

### DIFF
--- a/src/payload_builder.rs
+++ b/src/payload_builder.rs
@@ -22,8 +22,9 @@ pub struct PayloadInfo {
     pub block_number: u64,
     /// Execution state root.
     ///
-    /// We use this as the state root of the block built upon this block. With 0 transactions, the
-    /// state root does not change!
+    /// We use this as the state root of the block built upon this block. For Bellatrix this allows
+    /// us to build valid blocks, but post-Capella this doesn't work because the withdrawals
+    /// affect the state root and we can't compute that change without an EL.
     pub state_root: Hash256,
     /// For EIP-1559 calculations.
     pub base_fee_per_gas: Uint256,


### PR DESCRIPTION
I got a bit carried away in #18 and forgot that building a valid Capella payload without the EL is actually impossible. This PR amends the comments to accurately reflect the fact that Eleel can't actually build valid Capella payloads.