### PR TITLE
Only wait for recent newPayload calls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,12 @@ pub struct Config {
     /// the behaviour of a full execution engine.
     #[arg(long, value_name = "MILLIS", default_value = "2000")]
     pub new_payload_wait_millis: u128,
+    /// Maximum age of a payload that will trigger a wait on `newPayload`
+    ///
+    /// Payloads older than this age receive an instant SYNCING response. See docs for
+    /// `--new-payload-wait-millis` for the purpose of this wait.
+    #[arg(long, value_name = "NUM_BLOCKS", default_value = "64")]
+    pub new_payload_wait_cutoff: u64,
     /// Maximum time that a consensus node should wait for a forkchoiceUpdated response from the
     /// cache.
     ///

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -19,7 +19,7 @@ use tokio::sync::Mutex;
 pub struct Multiplexer<E: EthSpec> {
     pub engine: Engine,
     pub fcu_cache: Mutex<LruCache<JsonForkchoiceStateV1, JsonPayloadStatusV1>>,
-    pub new_payload_cache: Mutex<LruCache<ExecutionBlockHash, JsonPayloadStatusV1>>,
+    pub new_payload_cache: Mutex<LruCache<ExecutionBlockHash, NewPayloadCacheEntry>>,
     pub justified_block_cache: Mutex<LruCache<ExecutionBlockHash, ()>>,
     pub finalized_block_cache: Mutex<LruCache<ExecutionBlockHash, ()>>,
     pub payload_builder: Mutex<PayloadBuilder<E>>,
@@ -28,6 +28,11 @@ pub struct Multiplexer<E: EthSpec> {
     pub config: Config,
     pub log: Logger,
     _phantom: PhantomData<E>,
+}
+
+pub struct NewPayloadCacheEntry {
+    pub status: JsonPayloadStatusV1,
+    pub block_number: u64,
 }
 
 impl<E: EthSpec> Multiplexer<E> {


### PR DESCRIPTION
Closes #5

This just changes the wait behaviour for `newPayload`.

Determining recency for `fcU` is too hard: if it's a block we don't know then we have no idea what its block number is.